### PR TITLE
soft_barcode to render directly

### DIFF
--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -603,19 +603,16 @@ class Escpos(object):
                 )
             )
 
-        # Render the barcode to a fake file
+        # Render the barcode
         barcode_class = barcode.get_barcode_class(barcode_type)
         my_code = barcode_class(data, writer=image_writer)
-
-        with open(os.devnull, "wb") as nullfile:
-            my_code.write(
-                nullfile,
-                {
-                    "module_height": module_height,
-                    "module_width": module_width,
-                    "text_distance": text_distance,
-                },
-            )
+        my_code.render(
+            writer_options={
+                "module_height": module_height,
+                "module_width": module_width,
+                "text_distance": text_distance,
+            }
+        )
 
         # Retrieve the Pillow image and print it
         image = my_code.writer._image


### PR DESCRIPTION
Rendering to /dev/null was causing the soft_barcode method to error. Fix it by calling .render directly.

### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I have read the CONTRIBUTING.rst
- [x] I have tested my contribution on these devices:
 * ZJ-5870
- [x] My contribution is ready to be merged as is

----------

### Description
Switch to calling render directly to avoid errors in soft_barcode.
